### PR TITLE
chore: release v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "support-kit"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "bon",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["support-kit", "examples/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.dependencies]
-support-kit = { version = "0.0.1", path = "./support-kit" }
+support-kit = { version = "0.0.2", path = "./support-kit" }
 bon = "2.3.0"
 clap = { version = "4.5.4", features = ["derive", "env"] }
 convert_case = "0.6.0"

--- a/support-kit/CHANGELOG.md
+++ b/support-kit/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.1...support-kit-v0.0.2) - 2024-10-10
+
+### Other
+
+- Add a server address fetcher. ([#7](https://github.com/esmevane/support-kit/pull/7))
+- release ([#5](https://github.com/esmevane/support-kit/pull/5))
+
 ## [0.0.1](https://github.com/esmevane/support-kit/releases/tag/support-kit-v0.0.1) - 2024-10-10
 
 ### Other

--- a/support-kit/Cargo.toml
+++ b/support-kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "support-kit"
-version = "0.0.1"
+version = "0.0.2"
 description = "Some cli, config, service, and tracing boilerplate for networked applications."
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `support-kit`: 0.0.1 -> 0.0.2 (⚠️ API breaking changes)

### ⚠️ `support-kit` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant SupportKitError:NetworkInitError in /tmp/.tmpLKg3IP/support-kit/support-kit/src/errors.rs:41
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).