### PR TITLE
feat!(service): install allows custom args

### DIFF
--- a/examples/consumer/src/main.rs
+++ b/examples/consumer/src/main.rs
@@ -1,11 +1,18 @@
-use support_kit::reexports::{clap::Parser, owo_colors::OwoColorize};
+use support_kit::reexports::{clap::Parser, owo_colors::OwoColorize, tracing};
 
 fn main() -> support_kit::Result<()> {
     let args = support_kit::Args::parse();
-    let control = support_kit::SupportControl::load_configuration(&args)?.init();
+    let controller = support_kit::SupportControl::load_configuration(&args)?.init();
 
     println!("{:#?}", args.bright_green());
-    println!("{:#?}", control.bright_blue());
+    println!("{:#?}", controller.bright_blue());
+
+    tracing::debug!(config = ?controller.config, "loaded configuration");
+
+    match &args.command {
+        Some(_) => controller.execute(args)?,
+        None => {}
+    }
 
     Ok(())
 }

--- a/support-kit/src/args/service_args.rs
+++ b/support-kit/src/args/service_args.rs
@@ -31,7 +31,7 @@ fn operations() -> Result<(), Box<dyn std::error::Error>> {
 
     let expectations = [
         ("app service", None),
-        ("app service install", Some(Install)),
+        ("app service install", Some(Install(Default::default()))),
         ("app service start", Some(Start)),
         ("app service stop", Some(Stop)),
         ("app service uninstall", Some(Uninstall)),

--- a/support-kit/src/lib.rs
+++ b/support-kit/src/lib.rs
@@ -78,7 +78,10 @@ mod tests {
         let expectations = [
             ("app", None),
             ("app local", None),
-            ("app service install", Some(Commands::from(Install))),
+            (
+                "app service install",
+                Some(Commands::from(Install(Default::default()))),
+            ),
             ("app service start", Some(Commands::from(Start))),
             ("app service stop", Some(Commands::from(Stop))),
             ("app service uninstall", Some(Commands::from(Uninstall))),

--- a/support-kit/src/service/service_command.rs
+++ b/support-kit/src/service/service_command.rs
@@ -1,17 +1,24 @@
+use std::ffi::OsString;
+
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use strum::{EnumString, VariantNames};
 
-#[derive(
-    Copy, Clone, Debug, Deserialize, Parser, EnumString, VariantNames, Serialize, PartialEq,
-)]
+#[derive(Clone, Debug, Deserialize, Parser, EnumString, VariantNames, Serialize, PartialEq)]
 #[clap(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
 pub enum ServiceCommand {
-    Install,
+    Install(InstallArgs),
     Uninstall,
     Start,
     Stop,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Parser, Serialize, PartialEq)]
+#[clap(rename_all = "kebab-case")]
+pub struct InstallArgs {
+    #[clap(raw = true, required = false)]
+    pub args: Vec<OsString>,
 }
 
 impl ServiceCommand {

--- a/support-kit/src/service/service_control.rs
+++ b/support-kit/src/service/service_control.rs
@@ -20,7 +20,6 @@ impl std::fmt::Debug for ServiceControl {
             .field("manager level", &self.manager.level())
             .field("manager available", &self.manager.available())
             .field("program", &self.program())
-            .field("args", &self.args())
             .finish()
     }
 }
@@ -55,20 +54,17 @@ impl ServiceControl {
         Ok(std::env::current_exe()?)
     }
 
-    fn args(&self) -> Vec<OsString> {
-        vec![
-            "-n".into(),
-            self.name.to_string().into(),
-            "server".into(),
-            "api".into(),
-        ]
-    }
-
     #[tracing::instrument(level = "trace")]
     pub fn execute(&self, operation: ServiceCommand) -> Result<(), ServiceControlError> {
-        tracing::trace!(operation = ?operation, "executing operation");
         match operation {
-            ServiceCommand::Install => self.install(self.program()?, self.args()),
+            ServiceCommand::Install(install) => {
+                tracing::trace!(
+                    install_args = ?install,
+                    "installing with args"
+                );
+
+                self.install(self.program()?, install.args)
+            }
             ServiceCommand::Start => self.start(),
             ServiceCommand::Stop => self.stop(),
             ServiceCommand::Uninstall => self.uninstall(),


### PR DESCRIPTION
We didn't have a way to run custom args with our services. Instead it was a baked list of args that had no extensibility whatsoever. This commit introduces a way to allow custom args to be passed through to the installed service, after a trailing double-dash (`--`).