### PR TITLE
chore: release v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "support-kit"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "bon",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["support-kit", "examples/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.dependencies]
-support-kit = { version = "0.0.2", path = "./support-kit" }
+support-kit = { version = "0.0.3", path = "./support-kit" }
 bon = "2.3.0"
 clap = { version = "4.5.4", features = ["derive", "env"] }
 convert_case = "0.6.0"

--- a/support-kit/CHANGELOG.md
+++ b/support-kit/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.2...support-kit-v0.0.3) - 2024-10-10
+
+### Added
+
+- feat!(service): install allows custom args ([#8](https://github.com/esmevane/support-kit/pull/8))
+
 ## [0.0.2](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.1...support-kit-v0.0.2) - 2024-10-10
 
 ### Other

--- a/support-kit/Cargo.toml
+++ b/support-kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "support-kit"
-version = "0.0.2"
+version = "0.0.3"
 description = "Some cli, config, service, and tracing boilerplate for networked applications."
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `support-kit`: 0.0.2 -> 0.0.3 (⚠️ API breaking changes)

### ⚠️ `support-kit` breaking changes

```
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type ServiceCommand no longer derives Copy, in /tmp/.tmpmSMjyw/support-kit/support-kit/src/service/service_command.rs:10

--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant ServiceCommand::Install in /tmp/.tmpmSMjyw/support-kit/support-kit/src/service/service_command.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).