### PR TITLE
chore: release v0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "support-kit"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "async-trait",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["support-kit", "examples/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.dependencies]
-support-kit = { version = "0.0.6", path = "./support-kit" }
+support-kit = { version = "0.0.7", path = "./support-kit" }
 async-trait = "0.1.83"
 axum-server = { version = "0.7.1" }
 bon = "2.3.0"

--- a/support-kit/CHANGELOG.md
+++ b/support-kit/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.6...support-kit-v0.0.7) - 2024-10-23
+
+### Added
+
+- Add container config & tracing. ([#16](https://github.com/esmevane/support-kit/pull/16))
+
 ## [0.0.6](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.5...support-kit-v0.0.6) - 2024-10-23
 
 ### Fixed

--- a/support-kit/Cargo.toml
+++ b/support-kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "support-kit"
-version = "0.0.6"
+version = "0.0.7"
 description = "Some cli, config, service, and tracing boilerplate for networked applications."
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `support-kit`: 0.0.6 -> 0.0.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).