### PR TITLE
chore: release v0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2855,7 +2855,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "support-kit"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "async-trait",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["support-kit", "examples/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.dependencies]
-support-kit = { version = "0.0.7", path = "./support-kit" }
+support-kit = { version = "0.0.8", path = "./support-kit" }
 async-trait = "0.1.83"
 axum-server = { version = "0.7.1" }
 bon = "2.3.0"

--- a/support-kit/CHANGELOG.md
+++ b/support-kit/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.7...support-kit-v0.0.8) - 2024-10-26
+
+### Other
+
+- Container polish ([#18](https://github.com/esmevane/support-kit/pull/18))
+
 ## [0.0.7](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.6...support-kit-v0.0.7) - 2024-10-23
 
 ### Added

--- a/support-kit/Cargo.toml
+++ b/support-kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "support-kit"
-version = "0.0.7"
+version = "0.0.8"
 description = "Some cli, config, service, and tracing boilerplate for networked applications."
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `support-kit`: 0.0.7 -> 0.0.8 (⚠️ API breaking changes)

### ⚠️ `support-kit` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_missing.ron

Failed in:
  enum support_kit::OpsProcessError, previously in file /tmp/.tmpNAirXP/support-kit/src/errors.rs:5
  enum support_kit::Tls, previously in file /tmp/.tmpNAirXP/support-kit/src/deploy.rs:71
  enum support_kit::ContainerOp, previously in file /tmp/.tmpNAirXP/support-kit/src/containers/container_op.rs:9

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant SupportKitError:BoilerplateError in /tmp/.tmp2Rz5Vn/support-kit/support-kit/src/errors.rs:86
  variant SshError:InvalidPath in /tmp/.tmp2Rz5Vn/support-kit/support-kit/src/errors.rs:51
  variant Commands:Deploy in /tmp/.tmp2Rz5Vn/support-kit/support-kit/src/args.rs:61
  variant Commands:Generate in /tmp/.tmp2Rz5Vn/support-kit/support-kit/src/args.rs:62
  variant Commands:Container in /tmp/.tmp2Rz5Vn/support-kit/support-kit/src/args.rs:63

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  SupportControl::on_hosts, previously in file /tmp/.tmpNAirXP/support-kit/src/support_control.rs:64

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_missing.ron

Failed in:
  struct support_kit::ContainerControl, previously in file /tmp/.tmpNAirXP/support-kit/src/containers/container_control.rs:5
  struct support_kit::Host, previously in file /tmp/.tmpNAirXP/support-kit/src/deploy.rs:56
  struct support_kit::ImageControl, previously in file /tmp/.tmpNAirXP/support-kit/src/containers/image_control.rs:7
  struct support_kit::SshHost, previously in file /tmp/.tmpNAirXP/support-kit/src/ssh.rs:27
  struct support_kit::OpsProcess, previously in file /tmp/.tmpNAirXP/support-kit/src/containers/ops_process.rs:4
  struct support_kit::SshControl, previously in file /tmp/.tmpNAirXP/support-kit/src/ssh.rs:155
  struct support_kit::Deployment, previously in file /tmp/.tmpNAirXP/support-kit/src/deploy.rs:6
  struct support_kit::Image, previously in file /tmp/.tmpNAirXP/support-kit/src/deploy.rs:36
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).