### PR TITLE
chore: release v0.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2855,7 +2855,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "support-kit"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["support-kit", "examples/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.dependencies]
-support-kit = { version = "0.0.8", path = "./support-kit" }
+support-kit = { version = "0.0.9", path = "./support-kit" }
 async-trait = "0.1.83"
 axum-server = { version = "0.7.1" }
 bon = "2.3.0"

--- a/support-kit/CHANGELOG.md
+++ b/support-kit/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.9](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.8...support-kit-v0.0.9) - 2024-10-28
+
+### Added
+
+- Generate base config. ([#20](https://github.com/esmevane/support-kit/pull/20))
+
 ## [0.0.8](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.7...support-kit-v0.0.8) - 2024-10-26
 
 ### Other

--- a/support-kit/Cargo.toml
+++ b/support-kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "support-kit"
-version = "0.0.8"
+version = "0.0.9"
 description = "Some cli, config, service, and tracing boilerplate for networked applications."
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `support-kit`: 0.0.8 -> 0.0.9 (⚠️ API breaking changes)

### ⚠️ `support-kit` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field BoilerplateControl.config in /tmp/.tmpZBYMPk/support-kit/support-kit/src/boilerplate/boilerplate_control.rs:10

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant BoilerplatePreset:CrateConfig in /tmp/.tmpZBYMPk/support-kit/support-kit/src/boilerplate/boilerplate_preset.rs:13
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).