### PR TITLE
chore: release v0.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "support-kit"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["support-kit", "examples/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.dependencies]
-support-kit = { version = "0.0.10", path = "./support-kit" }
+support-kit = { version = "0.0.11", path = "./support-kit" }
 async-trait = "0.1.83"
 axum-server = { version = "0.7.1" }
 bon = "2.3.0"

--- a/support-kit/CHANGELOG.md
+++ b/support-kit/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.10...support-kit-v0.0.11) - 2024-11-05
+
+### Added
+
+- Merge downstream configs. ([#28](https://github.com/esmevane/support-kit/pull/28))
+
+### Fixed
+
+- Predictable paths for container start. ([#25](https://github.com/esmevane/support-kit/pull/25))
+
+### Other
+
+- drop axum server ([#27](https://github.com/esmevane/support-kit/pull/27))
+
 ## [0.0.10](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.9...support-kit-v0.0.10) - 2024-10-30
 
 ### Added

--- a/support-kit/Cargo.toml
+++ b/support-kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "support-kit"
-version = "0.0.10"
+version = "0.0.11"
 description = "Some cli, config, service, and tracing boilerplate for networked applications."
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `support-kit`: 0.0.10 -> 0.0.11 (⚠️ API breaking changes)

### ⚠️ `support-kit` breaking changes

```
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type DeploymentContext is no longer UnwindSafe, in /tmp/.tmp5FoXmB/support-kit/support-kit/src/deployments/deployment_context.rs:10
  type DeploymentContext is no longer RefUnwindSafe, in /tmp/.tmp5FoXmB/support-kit/support-kit/src/deployments/deployment_context.rs:10

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field DeploymentContext.figment in /tmp/.tmp5FoXmB/support-kit/support-kit/src/deployments/deployment_context.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).