### PR TITLE
fix: Auth token creation accepts uuid.

### DIFF
--- a/support-kit/src/encryption/token_control.rs
+++ b/support-kit/src/encryption/token_control.rs
@@ -20,8 +20,7 @@ impl TokenControl {
         Self(config)
     }
 
-    pub fn auth_token(&self) -> crate::Result<String> {
-        let id = uuid::Uuid::new_v4();
+    pub fn auth_token(&self, id: uuid::Uuid) -> crate::Result<String> {
         let secret = self.0.secret.clone();
 
         Ok(generate_auth_token(&id, &secret)?)


### PR DESCRIPTION
We need some kind of unique identifier to put into the token controller, or else it can't actually distinguish the json web tokens it makes. This commit adds support for that.