### PR TITLE
chore: release v0.0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,7 +3040,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "support-kit"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1"
 service-manager = { version = "0.6.1", features = ["clap", "serde"] }
 shell-escape = "0.1.5"
 strum = { version = "0.26.2", features = ["derive"] }
-support-kit = { version = "0.0.12", path = "./support-kit" }
+support-kit = { version = "0.0.13", path = "./support-kit" }
 thiserror = "1.0.59"
 tokio = { version = "1.40.0", features = ["io-std"] }
 tokio-stream = "0.1.16"

--- a/support-kit/CHANGELOG.md
+++ b/support-kit/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.12...support-kit-v0.0.13) - 2024-11-19
+
+### Fixed
+
+- Auth token creation accepts uuid. ([#31](https://github.com/esmevane/support-kit/pull/31))
+
 ## [0.0.12](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.11...support-kit-v0.0.12) - 2024-11-17
 
 ### Added

--- a/support-kit/Cargo.toml
+++ b/support-kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "support-kit"
-version = "0.0.12"
+version = "0.0.13"
 description = "Some cli, config, service, and tracing boilerplate for networked applications."
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `support-kit`: 0.0.12 -> 0.0.13 (⚠️ API breaking changes)

### ⚠️ `support-kit` breaking changes

```
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/method_parameter_count_changed.ron

Failed in:
  support_kit::TokenControl::auth_token now takes 2 parameters instead of 1, in /tmp/.tmpVLJ3l3/support-kit/support-kit/src/encryption/token_control.rs:23
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).