### PR TITLE
chore: release v0.0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,7 +2928,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "support-kit"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = "1"
 service-manager = { version = "0.6.1", features = ["clap", "serde"] }
 shell-escape = "0.1.5"
 strum = { version = "0.26.2", features = ["derive"] }
-support-kit = { version = "0.0.14", path = "./support-kit" }
+support-kit = { version = "0.0.15", path = "./support-kit" }
 thiserror = "1.0.59"
 tokio = { version = "1.40.0", features = ["io-std"] }
 tokio-stream = "0.1.16"

--- a/support-kit/CHANGELOG.md
+++ b/support-kit/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.15](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.14...support-kit-v0.0.15) - 2025-04-16
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.0.14](https://github.com/esmevane/support-kit/compare/support-kit-v0.0.13...support-kit-v0.0.14) - 2025-04-07
 
 ### Other

--- a/support-kit/Cargo.toml
+++ b/support-kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "support-kit"
-version = "0.0.14"
+version = "0.0.15"
 description = "Some cli, config, service, and tracing boilerplate for networked applications."
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `support-kit`: 0.0.14 -> 0.0.15 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).